### PR TITLE
State bypass away and freeze

### DIFF
--- a/custom_components/neviweb/climate.py
+++ b/custom_components/neviweb/climate.py
@@ -35,7 +35,8 @@ NEVIWEB_TO_HA_STATE = {
     0: STATE_OFF,
     2: STATE_MANUAL,
     3: STATE_AUTO,
-    131: STATE_STANDBY
+    131: STATE_STANDBY,
+    133: STATE_STANDBY
 }
 HA_TO_NEVIWEB_STATE = {
     value: key for key, value in NEVIWEB_TO_HA_STATE.items()
@@ -91,7 +92,8 @@ class NeviwebThermostat(ClimateDevice):
                 self._cur_temp = float(device_data["temperature"])
                 self._target_temp = float(device_data["setpoint"]) if \
                     device_data["setpoint"] is not None else 0.0
-                self._heat_level = device_data["heatLevel"]
+                self._heat_level = device_data["heatLevel"] if \
+                    device_data["heatLevel"] is not None else 0
                 self._alarm = device_data["alarm"]
                 self._rssi = device_data["rssi"]
                 if device_data["mode"] != NEVIWEB_STATE_AWAY:
@@ -216,7 +218,7 @@ class NeviwebThermostat(ClimateDevice):
 
     def turn_away_mode_off(self):
         """Turn away mode off."""
-        if self._operation_mode == 131:
+        if self._operation_mode >= 131:
             self._operation_mode = 3 
         self._client.set_mode(self._id, self._operation_mode)
         self._is_away = False

--- a/custom_components/neviweb/climate.py
+++ b/custom_components/neviweb/climate.py
@@ -35,6 +35,7 @@ NEVIWEB_TO_HA_STATE = {
     0: STATE_OFF,
     2: STATE_MANUAL,
     3: STATE_AUTO,
+    129: STATE_STANDBY,
     131: STATE_STANDBY,
     133: STATE_STANDBY
 }
@@ -218,7 +219,7 @@ class NeviwebThermostat(ClimateDevice):
 
     def turn_away_mode_off(self):
         """Turn away mode off."""
-        if self._operation_mode >= 131:
+        if self._operation_mode >= 129:
             self._operation_mode = 3 
         self._client.set_mode(self._id, self._operation_mode)
         self._is_away = False


### PR DESCRIPTION
1- Today I got an error about mode 133 which is when HA change set-point, from automation, and the device is in away mode. In that case HA could not switch back away mode to off because the mode 133 was not known in def turn_away_mode_off(self):
2- Secondly if for any reason on thermostat is disconnected, breaker off or physically disconnected, it raise an error in def is_on(self): property because self._heat_level is set to None for that device and None > 0 is wrong, cannot compare None to int.
With Lovelace it give 'Entity not available' for that device but in the state UI the device just disappeared. Could be fine if we can get a notice that one device is not there any more. For now I just set None heat_level to be equal to 0 to prevent that error. 
3- there is also another mode 129 which is bypass freeze protect. I think that freeze protect (mode 1) is for floor thermostat but in that case maybe it's better to take that into consideration for  def turn_away_mode_off(self): That won't work if mode is set to 129.
Freeze protect mode 1 is not defined in HA but maybe we can set it to STATE_UNKNOWN until it get defined in HA.