### PR TITLE
HA 0.96 climate cleanup

### DIFF
--- a/custom_components.json
+++ b/custom_components.json
@@ -1,6 +1,6 @@
 {
     "neviweb": {
-        "version": "1.0.0",
+        "version": "1.0.1",
         "local_location": "/custom_components/neviweb/__init__.py",
         "remote_location": "https://github.com/claudegel/sinope-1/tree/master/custom_components/neviweb/__init__.py",
         "visit_repo": "https://github.com/claudegel/sinope-1",

--- a/custom_components/neviweb/climate.py
+++ b/custom_components/neviweb/climate.py
@@ -16,8 +16,8 @@ from . import (SCAN_INTERVAL)
 from homeassistant.components.climate import ClimateDevice
 from homeassistant.components.climate.const import (HVAC_MODE_HEAT, 
     HVAC_MODE_OFF, HVAC_MODE_AUTO, SUPPORT_TARGET_TEMPERATURE, 
-    SUPPORT_PRESET_MODE, PRESET_AWAY, CURRENT_HVAC_HEAT, CURRENT_HVAC_IDLE,
-    CURRENT_HVAC_OFF)
+    SUPPORT_PRESET_MODE, PRESET_AWAY, PRESET_NONE, CURRENT_HVAC_HEAT, 
+    CURRENT_HVAC_IDLE, CURRENT_HVAC_OFF)
 from homeassistant.const import (TEMP_CELSIUS, TEMP_FAHRENHEIT, 
     ATTR_TEMPERATURE)
 from datetime import timedelta
@@ -43,9 +43,10 @@ NEVIWEB_MODE_AUTO_BYPASS = (NEVIWEB_MODE_AUTO | NEVIWEB_BYPASS_FLAG)
 
 SUPPORTED_HVAC_MODES = [HVAC_MODE_OFF, HVAC_MODE_AUTO, HVAC_MODE_HEAT]
 
-PRESET_BYPASS = 'bypass'
+PRESET_BYPASS = 'hold'
 PRESET_FREEZE_PROTECT = 'freeze protect'
 PRESET_MODES = [
+    PRESET_NONE,
     PRESET_AWAY,
     PRESET_BYPASS,
     PRESET_FREEZE_PROTECT
@@ -193,7 +194,7 @@ class NeviwebThermostat(ClimateDevice):
         elif self._operation_mode == NEVIWEB_MODE_AWAY:
             return PRESET_AWAY
         else:
-            return None
+            return PRESET_NONE
 
     @property
     def hvac_action(self):
@@ -237,5 +238,8 @@ class NeviwebThermostat(ClimateDevice):
             if self._operation_mode in NEVIWEB_BYPASSABLE_MODES:
                 self._client.set_mode(self._id, self._operation_mode | 
                 NEVIWEB_BYPASS_FLAG)
+        elif preset_mode == PRESET_NONE:
+            # Re-apply current hvac_mode without any preset
+            self.set_hvac_mode(self.hvac_mode)
         else:
             _LOGGER.error("Unable to set preset mode: %s.", preset_mode)

--- a/custom_components/neviweb/climate.py
+++ b/custom_components/neviweb/climate.py
@@ -43,13 +43,11 @@ NEVIWEB_MODE_AUTO_BYPASS = (NEVIWEB_MODE_AUTO | NEVIWEB_BYPASS_FLAG)
 
 SUPPORTED_HVAC_MODES = [HVAC_MODE_OFF, HVAC_MODE_AUTO, HVAC_MODE_HEAT]
 
-PRESET_BYPASS = 'hold'
-PRESET_FREEZE_PROTECT = 'freeze protect'
+PRESET_BYPASS = 'temporary'
 PRESET_MODES = [
     PRESET_NONE,
     PRESET_AWAY,
-    PRESET_BYPASS,
-    PRESET_FREEZE_PROTECT
+    PRESET_BYPASS
 ]
 
 IMPLEMENTED_DEVICE_TYPES = [10, 20, 21]
@@ -189,8 +187,6 @@ class NeviwebThermostat(ClimateDevice):
         """Return current preset mode."""
         if self._operation_mode & NEVIWEB_BYPASS_FLAG == NEVIWEB_BYPASS_FLAG:
             return PRESET_BYPASS
-        elif self._operation_mode == NEVIWEB_MODE_FREEZE_PROTECT:
-            return PRESET_FREEZE_PROTECT
         elif self._operation_mode == NEVIWEB_MODE_AWAY:
             return PRESET_AWAY
         else:
@@ -232,8 +228,6 @@ class NeviwebThermostat(ClimateDevice):
 
         if preset_mode == PRESET_AWAY:
             self._client.set_mode(self._id, NEVIWEB_MODE_AWAY)
-        elif preset_mode == PRESET_FREEZE_PROTECT:
-            self._client.set_mode(self._id, NEVIWEB_MODE_FREEZE_PROTECT)
         elif preset_mode == PRESET_BYPASS:
             if self._operation_mode in NEVIWEB_BYPASSABLE_MODES:
                 self._client.set_mode(self._id, self._operation_mode | 

--- a/custom_components/neviweb/climate.py
+++ b/custom_components/neviweb/climate.py
@@ -13,39 +13,43 @@ import time
 
 import custom_components.neviweb as neviweb
 from . import (SCAN_INTERVAL)
-from homeassistant.components.climate import (ClimateDevice, ATTR_TEMPERATURE,
-    ATTR_AWAY_MODE, ATTR_OPERATION_MODE, ATTR_OPERATION_LIST, ATTR_CURRENT_TEMPERATURE)
-from homeassistant.components.climate.const import (STATE_HEAT, 
-    STATE_IDLE, STATE_AUTO, STATE_MANUAL, SUPPORT_TARGET_TEMPERATURE,
-    SUPPORT_OPERATION_MODE, SUPPORT_AWAY_MODE, SUPPORT_ON_OFF)
-from homeassistant.const import (TEMP_CELSIUS, TEMP_FAHRENHEIT, STATE_OFF)
+from homeassistant.components.climate import ClimateDevice
+from homeassistant.components.climate.const import (HVAC_MODE_HEAT, 
+    HVAC_MODE_OFF, HVAC_MODE_AUTO, SUPPORT_TARGET_TEMPERATURE, 
+    SUPPORT_PRESET_MODE, PRESET_AWAY, CURRENT_HVAC_HEAT, CURRENT_HVAC_IDLE,
+    CURRENT_HVAC_OFF)
+from homeassistant.const import (TEMP_CELSIUS, TEMP_FAHRENHEIT, 
+    ATTR_TEMPERATURE)
 from datetime import timedelta
 from homeassistant.helpers.event import track_time_interval
 
 _LOGGER = logging.getLogger(__name__)
 
-SUPPORT_FLAGS = (SUPPORT_TARGET_TEMPERATURE | SUPPORT_OPERATION_MODE |
-    SUPPORT_AWAY_MODE | SUPPORT_ON_OFF)
+SUPPORT_FLAGS = (SUPPORT_TARGET_TEMPERATURE | SUPPORT_PRESET_MODE)
 
 DEFAULT_NAME = "neviweb climate"
 
-STATE_STANDBY = 'bypass'
-STATE_AWAY = 'away'
-NEVIWEB_STATE_AWAY = 5
-NEVIWEB_STATE_OFF = 0
-NEVIWEB_TO_HA_STATE = {
-    0: STATE_OFF,
-    2: STATE_MANUAL,
-    3: STATE_AUTO,
-    5: STATE_AWAY,
-    129: STATE_STANDBY,
-    131: STATE_STANDBY,
-    133: STATE_STANDBY
-}
-HA_TO_NEVIWEB_STATE = {
-    value: key for key, value in NEVIWEB_TO_HA_STATE.items()
-}
-OPERATION_LIST = [STATE_OFF, STATE_MANUAL, STATE_AUTO, STATE_AWAY, STATE_STANDBY]
+NEVIWEB_MODE_OFF = 0
+NEVIWEB_MODE_FREEZE_PROTECT = 1
+NEVIWEB_MODE_MANUAL = 2
+NEVIWEB_MODE_AUTO = 3
+NEVIWEB_MODE_AWAY = 5
+
+NEVIWEB_BYPASS_FLAG = 128
+NEVIWEB_BYPASSABLE_MODES = [NEVIWEB_MODE_FREEZE_PROTECT,
+                            NEVIWEB_MODE_AUTO,
+                            NEVIWEB_MODE_AWAY]
+NEVIWEB_MODE_AUTO_BYPASS = (NEVIWEB_MODE_AUTO | NEVIWEB_BYPASS_FLAG)
+
+SUPPORTED_HVAC_MODES = [HVAC_MODE_OFF, HVAC_MODE_AUTO, HVAC_MODE_HEAT]
+
+PRESET_BYPASS = 'bypass'
+PRESET_FREEZE_PROTECT = 'freeze protect'
+PRESET_MODES = [
+    PRESET_AWAY,
+    PRESET_BYPASS,
+    PRESET_FREEZE_PROTECT
+]
 
 IMPLEMENTED_DEVICE_TYPES = [10, 20, 21]
 
@@ -78,8 +82,7 @@ class NeviwebThermostat(ClimateDevice):
         self._rssi = None
         self._alarm = None
         self._operation_mode = None
-        self._heat_level = None
-        self._is_away = False
+        self._heat_level = 0
         _LOGGER.debug("Setting up %s: %s", self._name, device_info)
 
     def update(self):
@@ -101,11 +104,7 @@ class NeviwebThermostat(ClimateDevice):
                 self._alarm = device_data["alarm"]
                 self._rssi = device_data["rssi"]
                 self._operation_mode = device_data["mode"] if \
-                    device_data["mode"] is not None else 2
-                if device_data["mode"] != NEVIWEB_STATE_AWAY:
-                    self._is_away = False
-                else:
-                    self._is_away = True
+                    device_data["mode"] is not None else NEVIWEB_MODE_MANUAL
                 return
         elif "code" in device_data:
             _LOGGER.warning("Error while updating %s. %s: %s", self._name,
@@ -122,15 +121,6 @@ class NeviwebThermostat(ClimateDevice):
     def name(self):
         """Return the name of the thermostat."""
         return self._name
-
-    @property
-    def state(self):
-        """Return current state i.e. heat, off, idle."""
-        if self.is_on:
-            return STATE_HEAT
-        if self._operation_mode == NEVIWEB_STATE_OFF:
-            return STATE_OFF
-        return STATE_IDLE
 
     @property
     def device_state_attributes(self):
@@ -163,14 +153,20 @@ class NeviwebThermostat(ClimateDevice):
         return TEMP_CELSIUS
 
     @property
-    def current_operation(self):
-        """Return current operation i.e. off, auto, manual."""
-        return self.to_hass_operation_mode(self._operation_mode)
+    def hvac_mode(self):
+        """Return current operation"""
+        if self._operation_mode == NEVIWEB_MODE_OFF:
+            return HVAC_MODE_OFF
+        elif self._operation_mode in [NEVIWEB_MODE_AUTO, 
+                                      NEVIWEB_MODE_AUTO_BYPASS]:
+            return HVAC_MODE_AUTO
+        else:
+            return HVAC_MODE_HEAT
 
     @property
-    def operation_list(self):
+    def hvac_modes(self):
         """Return the list of available operation modes."""
-        return OPERATION_LIST
+        return SUPPORTED_HVAC_MODES
 
     @property
     def current_temperature(self):
@@ -183,14 +179,31 @@ class NeviwebThermostat(ClimateDevice):
         return self._target_temp
 
     @property
-    def is_away_mode_on(self):
-        return self._is_away
+    def preset_modes(self):
+        """Return available preset modes."""
+        return PRESET_MODES
 
     @property
-    def is_on(self):
-        if self._heat_level == None:
-            self._heat_level = 0
-        return self._heat_level > 0
+    def preset_mode(self):
+        """Return current preset mode."""
+        if self._operation_mode & NEVIWEB_BYPASS_FLAG == NEVIWEB_BYPASS_FLAG:
+            return PRESET_BYPASS
+        elif self._operation_mode == NEVIWEB_MODE_FREEZE_PROTECT:
+            return PRESET_FREEZE_PROTECT
+        elif self._operation_mode == NEVIWEB_MODE_AWAY:
+            return PRESET_AWAY
+        else:
+            return None
+
+    @property
+    def hvac_action(self):
+        """Return current HVAC action."""
+        if self._operation_mode == NEVIWEB_MODE_OFF:
+            return CURRENT_HVAC_OFF
+        elif self._heat_level == 0:
+            return CURRENT_HVAC_IDLE
+        else:
+            return CURRENT_HVAC_HEAT
 
     def set_temperature(self, **kwargs):
         """Set new target temperature."""
@@ -200,41 +213,29 @@ class NeviwebThermostat(ClimateDevice):
         self._client.set_temperature(self._id, temperature)
         self._target_temp = temperature
 
-    def set_operation_mode(self, operation_mode):
-        """Set new operation mode."""
-        mode = self.to_neviweb_operation_mode(operation_mode)
-        self._client.set_mode(self._id, mode)
+    def set_hvac_mode(self, hvac_mode):
+        """Set new hvac mode."""
+        if hvac_mode == HVAC_MODE_OFF:
+            self._client.set_mode(self._id, NEVIWEB_MODE_OFF)
+        elif hvac_mode == HVAC_MODE_HEAT:
+            self._client.set_mode(self._id, NEVIWEB_MODE_MANUAL)
+        elif hvac_mode == HVAC_MODE_AUTO:
+            self._client.set_mode(self._id, NEVIWEB_MODE_AUTO)
+        else:
+            _LOGGER.error("Unable to set hvac mode: %s.", hvac_mode)
 
-    def to_neviweb_operation_mode(self, mode):
-        """Translate hass operation modes to neviweb modes."""
-        if mode in HA_TO_NEVIWEB_STATE:
-            return HA_TO_NEVIWEB_STATE[mode]
-        _LOGGER.error("Operation mode %s could not be mapped to neviweb", mode)
-        return None
-        
-    def to_hass_operation_mode(self, mode):
-        """Translate neviweb operation modes to hass operation modes."""
-        if mode in NEVIWEB_TO_HA_STATE:
-            return NEVIWEB_TO_HA_STATE[mode]
-        _LOGGER.error("Operation mode %s could not be mapped to hass", mode)
-        return None
-    
-    def turn_away_mode_on(self):
-        """Turn away mode on."""
-        self._client.set_mode(self._id, NEVIWEB_STATE_AWAY)
-        self._is_away = True
+    def set_preset_mode(self, preset_mode):
+        """Activate a preset."""
+        if preset_mode == self.preset_mode:
+            return
 
-    def turn_away_mode_off(self):
-        """Turn away mode off."""
-        if self._operation_mode >= 129:
-            self._operation_mode = 3 
-        self._client.set_mode(self._id, self._operation_mode)
-        self._is_away = False
-        
-    def turn_off(self):
-        """Turn device off."""
-        self._client.set_mode(self._id, NEVIWEB_STATE_OFF)
-
-    def turn_on(self):
-        """Turn device on (auto mode)."""
-        self._client.set_mode(self._id, 3)
+        if preset_mode == PRESET_AWAY:
+            self._client.set_mode(self._id, NEVIWEB_MODE_AWAY)
+        elif preset_mode == PRESET_FREEZE_PROTECT:
+            self._client.set_mode(self._id, NEVIWEB_MODE_FREEZE_PROTECT)
+        elif preset_mode == PRESET_BYPASS:
+            if self._operation_mode in NEVIWEB_BYPASSABLE_MODES:
+                self._client.set_mode(self._id, self._operation_mode | 
+                NEVIWEB_BYPASS_FLAG)
+        else:
+            _LOGGER.error("Unable to set preset mode: %s.", preset_mode)


### PR DESCRIPTION
Hi Claude,
Here I have a working version of neviweb custom control with HA 0.96.3.
I chose to merge it directly in your master branch since there would be too many conflicts with your 0.96 branch.
The way I mapped neviweb modes with the new HVAC_MODES is the following:
HVAC_MODE_AUTO -> Auto
HVAC_MODE_HEAT -> Manual
I used preset to map Away mode and bypass (temporary) modes. 
So, in the Lovelace Thermostat card, we can use the schedule button to activate Auto mode, and the Flame button to activate Manual mode.